### PR TITLE
Change Radarr async_get_calendar to use date from datetime

### DIFF
--- a/aiopyarr/radarr_client.py
+++ b/aiopyarr/radarr_client.py
@@ -1,7 +1,7 @@
 """Radarr API."""
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any
 
 from aiohttp.client import ClientSession
@@ -589,16 +589,16 @@ class RadarrClient(RequestClient):  # pylint: disable=too-many-public-methods
 
     async def async_get_calendar(
         self,
-        start_date: datetime | None = None,
-        end_date: datetime | None = None,
+        start_date: date | None = None,
+        end_date: date | None = None,
         unmonitored: bool = True,
     ) -> list[RadarrCalendarItem]:
         """Get a list of movies based on calendar parameters."""
         params = {"unmonitored": str(unmonitored)}
         if start_date:
-            params["start"] = start_date.strftime("%Y-%m-%d")
+            params["start"] = str(start_date)
         if end_date:
-            params["end"] = end_date.strftime("%Y-%m-%d")
+            params["end"] = str(end_date)
         return await self._async_request(
             "calendar",
             params=params,

--- a/aiopyarr/radarr_client.py
+++ b/aiopyarr/radarr_client.py
@@ -1,7 +1,7 @@
 """Radarr API."""
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date as dt, datetime
 from typing import Any
 
 from aiohttp.client import ClientSession
@@ -589,8 +589,8 @@ class RadarrClient(RequestClient):  # pylint: disable=too-many-public-methods
 
     async def async_get_calendar(
         self,
-        start_date: date | None = None,
-        end_date: date | None = None,
+        start_date: dt | None = None,
+        end_date: dt | None = None,
         unmonitored: bool = True,
     ) -> list[RadarrCalendarItem]:
         """Get a list of movies based on calendar parameters."""

--- a/tests/test_radarr.py
+++ b/tests/test_radarr.py
@@ -152,8 +152,8 @@ async def test_async_get_calendar(aresponses, radarr_client: RadarrClient) -> No
         ),
         match_querystring=True,
     )
-    start = datetime.strptime("Nov 30 2020  1:33PM", "%b %d %Y %I:%M%p")
-    end = datetime.strptime("Dec 1 2020  1:33PM", "%b %d %Y %I:%M%p")
+    start = date(2020, 11, 30)
+    end = date(2020, 12, 1)
     data = await radarr_client.async_get_calendar(start, end)
 
     assert data[0].title == "string"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Radarr shows release dates, not datetime. This PR changes the `async_get_calendar` method to expect a `date` object instead for `start_date` and `end_date`.

## Type of change

<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted (`make lint`)
- [x] Tests have been added to verify that the new code works.
