### PR TITLE
Fix Attribute errors

### DIFF
--- a/aiopyarr/models/base.py
+++ b/aiopyarr/models/base.py
@@ -128,5 +128,5 @@ class BaseModel:
             if k in CONVERT_TO_INTEGER
             else toraw(v)
             for k, v in self.__dict__.items()
-            if k != "basedata"
+            if k != ATTR_DATA
         }

--- a/aiopyarr/models/lidarr.py
+++ b/aiopyarr/models/lidarr.py
@@ -314,6 +314,7 @@ class LidarrQueueItem(_Common4, _Common7, _Common8):
 
     def __post_init__(self):
         """Post init."""
+        super().__post_init__()
         self.album = _LidarrQueueItemAlbum(self.album)
         self.artist = _LidarrArtist(self.artist)
         self.quality = _Quality(self.quality)

--- a/aiopyarr/models/request_common.py
+++ b/aiopyarr/models/request_common.py
@@ -160,9 +160,12 @@ class _Common8(BaseModel):
 
     def __post_init__(self):
         """Post init."""
-        if hasattr(self, "sizeleft") and self.sizeleft > 0:
-            if self.timeleft and self.timeleft == "00:00:00":
-                self.trackedDownloadState = "stopped"
+        if (
+            hasattr(self, "sizeleft")
+            and self.sizeleft > 0
+            and self.timeleft == "00:00:00"
+        ):
+            self.trackedDownloadState = "stopped"
 
 
 @dataclass(init=False)

--- a/aiopyarr/models/request_common.py
+++ b/aiopyarr/models/request_common.py
@@ -81,7 +81,7 @@ class _Common4(BaseModel):
 
     downloadClient: str
     downloadId: str
-    estimatedCompletionTime: datetime
+    estimatedCompletionTime: datetime | None = None
     indexer: str
     outputPath: str
 
@@ -153,21 +153,16 @@ class _Common8(BaseModel):
     sizeleft: int
     status: str
     statusMessages: list[_StatusMessage] | None = None
-    timeleft: str
+    timeleft: str | None = None
     title: str
-    trackedDownloadState: str
+    trackedDownloadState: str = "downloading"
     trackedDownloadStatus: str
 
     def __post_init__(self):
         """Post init."""
-        if not hasattr(self, "timeleft"):
-            self.__setattr__("timeleft", "00:00:00")
-        if (
-            self.sizeleft > 0
-            and self.timeleft == "00:00:00"
-            or not hasattr(self, "trackedDownloadState")
-        ):
-            self.trackedDownloadState = "stopped"
+        if hasattr(self, "sizeleft") and self.sizeleft > 0:
+            if self.timeleft and self.timeleft == "00:00:00":
+                self.trackedDownloadState = "stopped"
 
 
 @dataclass(init=False)

--- a/tests/fixtures/lidarr/queue-2.json
+++ b/tests/fixtures/lidarr/queue-2.json
@@ -1,0 +1,43 @@
+{
+  "page": 1,
+  "pageSize": 20,
+  "sortKey": "timeleft",
+  "sortDirection": "ascending",
+  "totalRecords": 51,
+  "records": [
+    {
+      "artistId": 0,
+      "albumId": 0,
+      "quality": {
+        "quality": {
+          "id": 6,
+          "name": "FLAC"
+        },
+        "revision": {
+          "version": 1,
+          "real": 0,
+          "isRepack": false
+        }
+      },
+      "size": 20000,
+      "title": "string",
+      "sizeleft": 0,
+      "status": "completed",
+      "trackedDownloadStatus": "string",
+      "trackedDownloadState": "string",
+      "statusMessages": [
+        {
+          "title": "string",
+          "messages": ["string"]
+        }
+      ],
+      "downloadId": "string",
+      "protocol": "torrent",
+      "downloadClient": "Transmission",
+      "indexer": "string",
+      "outputPath": "string",
+      "downloadForced": false,
+      "id": 0
+    }
+  ]
+}

--- a/tests/fixtures/radarr/queue-2.json
+++ b/tests/fixtures/radarr/queue-2.json
@@ -1,0 +1,80 @@
+{
+    "page": 1,
+    "pageSize": 10,
+    "sortKey": "timeleft",
+    "sortDirection": "ascending",
+    "totalRecords": 1,
+    "records": [
+      {
+        "movieId": 0,
+        "languages": [
+          {
+            "id": 0,
+            "name": "string"
+          }
+        ],
+        "quality": {
+          "quality": {
+            "id": 0,
+            "name": "string",
+            "source": "string",
+            "resolution": 0,
+            "modifier": "string"
+          },
+          "revision": {
+            "version": 0,
+            "real": 0,
+            "isRepack": true
+          }
+        },
+        "customFormats": [
+          {
+            "id": 0,
+            "name": "string",
+            "includeCustomFormatWhenRenaming": true,
+            "specifications": [
+              {
+                "name": "string",
+                "implementation": "string",
+                "implementationName": "string",
+                "infoLink": "string",
+                "negate": true,
+                "required": true,
+                "fields": [
+                  {
+                    "order": 0,
+                    "name": "string",
+                    "label": "string",
+                    "helpText": "string",
+                    "value": "string",
+                    "type": "string",
+                    "advanced": true
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "size": 200000,
+        "title": "string",
+        "sizeleft": 100000,
+        "status": "string",
+        "trackedDownloadStatus": "string",
+        "trackedDownloadState": "downloading",
+        "statusMessages": [
+          {
+            "title": "string",
+            "messages": ["string"]
+          }
+        ],
+        "errorMessage": "string",
+        "downloadId": "string",
+        "protocol": "unknown",
+        "downloadClient": "string",
+        "indexer": "string",
+        "outputPath": "string",
+        "id": 0
+      }
+    ]
+  }
+  

--- a/tests/fixtures/readarr/queue-2.json
+++ b/tests/fixtures/readarr/queue-2.json
@@ -1,0 +1,92 @@
+{
+    "page": 1,
+    "pageSize": 10,
+    "sortKey": "timeleft",
+    "sortDirection": "ascending",
+    "totalRecords": 1,
+    "records": [
+      {
+        "authorId": 0,
+        "bookId": 0,
+        "author": {
+          "authorMetadataId": 0,
+          "status": "string",
+          "ended": false,
+          "authorName": "string",
+          "authorNameLastFirst": "string",
+          "foreignAuthorId": "0",
+          "titleSlug": "0",
+          "overview": "string",
+          "links": [
+            {
+              "url": "string",
+              "name": "string"
+            }
+          ],
+          "images": [
+            {
+              "url": "string",
+              "coverType": "poster",
+              "extension": "string"
+            }
+          ],
+          "path": "string",
+          "qualityProfileId": 0,
+          "metadataProfileId": 0,
+          "monitored": true,
+          "monitorNewItems": "string",
+          "genres": ["string"],
+          "cleanName": "string",
+          "sortName": "string",
+          "sortNameLastFirst": "string",
+          "tags": [0],
+          "added": "2020-11-06T23:38:03Z",
+          "ratings": {
+            "votes": 0,
+            "value": 0.0,
+            "popularity": 0.0
+          },
+          "statistics": {
+            "bookFileCount": 0,
+            "bookCount": 0,
+            "availableBookCount": 0,
+            "totalBookCount": 0,
+            "sizeOnDisk": 0,
+            "percentOfBooks": 0
+          },
+          "id": 72
+        },
+        "quality": {
+          "quality": {
+            "id": 0,
+            "name": "string"
+          },
+          "revision": {
+            "version": 0,
+            "real": 0,
+            "isRepack": false
+          }
+        },
+        "size": 200000,
+        "title": "string",
+        "sizeleft": 100000,
+        "status": "string",
+        "trackedDownloadStatus": "string",
+        "trackedDownloadState": "downloading",
+        "statusMessages": [
+          {
+            "title": "string",
+            "messages": ["string"]
+          }
+        ],
+        "downloadId": "string",
+        "protocol": "unknown",
+        "downloadClient": "string",
+        "indexer": "string",
+        "outputPath": "string",
+        "downloadForced": false,
+        "id": 0
+      }
+    ]
+  }
+  

--- a/tests/fixtures/sonarr/queue-2.json
+++ b/tests/fixtures/sonarr/queue-2.json
@@ -1,0 +1,48 @@
+{
+    "page": 1,
+    "pageSize": 10,
+    "sortKey": "timeleft",
+    "sortDirection": "ascending",
+    "totalRecords": 2,
+    "records": [
+      {
+        "seriesId": 0,
+        "episodeId": 0,
+        "language": {
+          "id": 0,
+          "name": "string"
+        },
+        "quality": {
+          "quality": {
+            "id": 0,
+            "name": "string",
+            "source": "string",
+            "resolution": 0
+          },
+          "revision": {
+            "version": 0,
+            "real": 0,
+            "isRepack": false
+          }
+        },
+        "size": 200000.0,
+        "title": "string",
+        "sizeleft": 100000.0,
+        "status": "string",
+        "trackedDownloadStatus": "string",
+        "statusMessages": [
+          {
+            "title": "string",
+            "messages": ["string"]
+          }
+        ],
+        "downloadId": "string",
+        "protocol": "unknown",
+        "downloadClient": "string",
+        "indexer": "string",
+        "outputPath": "string",
+        "id": 0
+      }
+    ]
+  }
+  

--- a/tests/test_lidarr.py
+++ b/tests/test_lidarr.py
@@ -1490,17 +1490,60 @@ async def test_async_get_queue(aresponses: Server, lidarr_client: LidarrClient) 
     assert _value.quality.revision.isRepack is False
     assert isinstance(_value.size, int)
     assert _value.title == "string"
-    assert isinstance(_value.sizeleft, int)
+    assert _value.sizeleft > 0
     assert _value.timeleft == "00:00:00"
     assert _value.estimatedCompletionTime == datetime(2020, 2, 16, 23, 34, 44, 885649)
     assert _value.status == "string"
     assert _value.trackedDownloadStatus == "string"
-    assert _value.trackedDownloadState == "string"
+    assert _value.trackedDownloadState == "stopped"
     assert _value.statusMessages[0].title == "string"
     assert _value.statusMessages[0].messages == ["string"]
     assert _value.downloadId == "string"
     assert _value.protocol is ProtocolType.UNKNOWN
     assert _value.downloadClient == "string"
+    assert _value.indexer == "string"
+    assert _value.outputPath == "string"
+    assert _value.downloadForced is False
+    assert isinstance(_value.id, int)
+
+    aresponses.add(
+        "127.0.0.1:8686",
+        f"/api/{LIDARR_API}/queue?page=1&pageSize=10&sortKey=timeleft&includeUnknownArtistItems=False&includeArtist=False&includeAlbum=False",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text=load_fixture("lidarr/queue-2.json"),
+        ),
+        match_querystring=True,
+    )
+    data = await lidarr_client.async_get_queue()
+    assert isinstance(data.page, int)
+    assert isinstance(data.page, int)
+    assert data.sortKey == LidarrSortKeys.TIMELEFT.value
+    assert data.sortDirection == SortDirection.ASCENDING.value
+    assert isinstance(data.totalRecords, int)
+    _value = data.records[0]
+    assert isinstance(_value.artistId, int)
+    assert isinstance(_value.albumId, int)
+    assert isinstance(_value.quality.quality.id, int)
+    assert _value.quality.quality.name == "FLAC"
+    assert isinstance(_value.quality.revision.version, int)
+    assert isinstance(_value.quality.revision.real, int)
+    assert _value.quality.revision.isRepack is False
+    assert isinstance(_value.size, int)
+    assert _value.title == "string"
+    assert _value.sizeleft == 0
+    assert _value.timeleft is None
+    assert _value.estimatedCompletionTime is None
+    assert _value.status == "completed"
+    assert _value.trackedDownloadStatus == "string"
+    assert _value.trackedDownloadState == "string"
+    assert _value.statusMessages[0].title == "string"
+    assert _value.statusMessages[0].messages == ["string"]
+    assert _value.downloadId == "string"
+    assert _value.protocol is ProtocolType.TORRENT
+    assert _value.downloadClient == "Transmission"
     assert _value.indexer == "string"
     assert _value.outputPath == "string"
     assert _value.downloadForced is False
@@ -1638,7 +1681,7 @@ async def test_async_get_queue_details(
     assert data[0].quality.revision.isRepack is False
     assert isinstance(data[0].size, int)
     assert data[0].title == "string"
-    assert isinstance(data[0].sizeleft, int)
+    assert data[0].sizeleft == 0
     assert data[0].timeleft == "00:00:00"
     assert data[0].estimatedCompletionTime == datetime(2020, 2, 16, 23, 49, 45, 143727)
     assert data[0].status == "string"

--- a/tests/test_radarr.py
+++ b/tests/test_radarr.py
@@ -977,9 +977,73 @@ async def test_async_get_queue(aresponses: Server, radarr_client: RadarrClient) 
     assert _value.specifications[0].fields[0].advanced is True
     assert isinstance(data.records[0].size, int)
     assert data.records[0].title == "string"
-    assert isinstance(data.records[0].sizeleft, int)
+    assert data.records[0].sizeleft > 0
     assert data.records[0].timeleft == "00:00:20"
     assert data.records[0].estimatedCompletionTime == datetime(2020, 1, 21, 0, 1, 59)
+    assert data.records[0].status == "string"
+    assert data.records[0].trackedDownloadStatus == "string"
+    assert data.records[0].trackedDownloadState == "downloading"
+    assert data.records[0].statusMessages[0].title == "string"
+    assert data.records[0].statusMessages[0].messages == ["string"]
+    assert data.records[0].errorMessage == "string"
+    assert data.records[0].downloadId == "string"
+    assert data.records[0].protocol is ProtocolType.UNKNOWN
+    assert data.records[0].downloadClient == "string"
+    assert data.records[0].indexer == "string"
+    assert data.records[0].outputPath == "string"
+    assert isinstance(data.records[0].id, int)
+
+    aresponses.add(
+        "127.0.0.1:7878",
+        f"/api/{RADARR_API}/queue?page=1&pageSize=20&sortDirection=default&sortKey=timeleft&includeUnknownMovieItems=False&includeMovie=False",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text=load_fixture("radarr/queue-2.json"),
+        ),
+        match_querystring=True,
+    )
+    data = await radarr_client.async_get_queue()
+
+    assert isinstance(data.page, int)
+    assert isinstance(data.pageSize, int)
+    assert data.sortKey == RadarrSortKeys.TIMELEFT.value
+    assert data.sortDirection == SortDirection.ASCENDING.value
+    assert isinstance(data.totalRecords, int)
+    assert isinstance(data.records[0].movieId, int)
+    assert isinstance(data.records[0].languages[0].id, int)
+    assert data.records[0].languages[0].name == "string"
+    assert isinstance(data.records[0].quality.quality.id, int)
+    assert data.records[0].quality.quality.name == "string"
+    assert data.records[0].quality.quality.source == "string"
+    assert isinstance(data.records[0].quality.quality.resolution, int)
+    assert data.records[0].quality.quality.modifier == "string"
+    assert isinstance(data.records[0].quality.revision.version, int)
+    assert isinstance(data.records[0].quality.revision.real, int)
+    assert data.records[0].quality.revision.isRepack is True
+    _value = data.records[0].customFormats[0]
+    assert isinstance(_value.id, int)
+    assert _value.name == "string"
+    assert _value.includeCustomFormatWhenRenaming is True
+    assert _value.specifications[0].name == "string"
+    assert _value.specifications[0].implementation == "string"
+    assert _value.specifications[0].implementationName == "string"
+    assert _value.specifications[0].infoLink == "string"
+    assert _value.specifications[0].negate is True
+    assert _value.specifications[0].required is True
+    assert isinstance(_value.specifications[0].fields[0].order, int)
+    assert _value.specifications[0].fields[0].name == "string"
+    assert _value.specifications[0].fields[0].label == "string"
+    assert _value.specifications[0].fields[0].helpText == "string"
+    assert _value.specifications[0].fields[0].value == "string"
+    assert _value.specifications[0].fields[0].type == "string"
+    assert _value.specifications[0].fields[0].advanced is True
+    assert isinstance(data.records[0].size, int)
+    assert data.records[0].title == "string"
+    assert data.records[0].sizeleft > 0
+    assert data.records[0].timeleft is None
+    assert data.records[0].estimatedCompletionTime is None
     assert data.records[0].status == "string"
     assert data.records[0].trackedDownloadStatus == "string"
     assert data.records[0].trackedDownloadState == "downloading"
@@ -1040,7 +1104,7 @@ async def test_async_get_queue_details(
     assert data[0].customFormats[0].specifications[0].fields[0].advanced is True
     assert isinstance(data[0].size, int)
     assert data[0].title == "string"
-    assert isinstance(data[0].sizeleft, int)
+    assert data[0].sizeleft == 0
     assert data[0].timeleft == "string"
     assert data[0].estimatedCompletionTime == datetime(2020, 1, 21, 0, 1, 59)
     assert data[0].status == "string"

--- a/tests/test_readarr.py
+++ b/tests/test_readarr.py
@@ -5696,9 +5696,53 @@ async def test_async_get_queue(
     assert data.records[0].quality.revision.isRepack is False
     assert isinstance(data.records[0].size, int)
     assert data.records[0].title == "string"
-    assert isinstance(data.records[0].sizeleft, int)
+    assert data.records[0].sizeleft > 0
     assert data.records[0].timeleft == "00:00:10"
     assert data.records[0].estimatedCompletionTime == datetime(2020, 2, 9, 23, 22, 30)
+    assert data.records[0].status == "string"
+    assert data.records[0].trackedDownloadStatus == "string"
+    assert data.records[0].trackedDownloadState == "downloading"
+    assert data.records[0].statusMessages[0].title == "string"
+    assert data.records[0].statusMessages[0].messages == ["string"]
+    assert data.records[0].downloadId == "string"
+    assert data.records[0].protocol is ProtocolType.UNKNOWN
+    assert data.records[0].downloadClient == "string"
+    assert data.records[0].indexer == "string"
+    assert data.records[0].outputPath == "string"
+    assert data.records[0].downloadForced is False
+    assert isinstance(data.records[0].id, int)
+
+    aresponses.add(
+        "127.0.0.1:8787",
+        f"/api/{READARR_API}/queue?page=1&pageSize=10&sortKey=timeleft&includeUnknownAuthorItems=False&includeAuthor=False&includeBook=False",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text=load_fixture("readarr/queue-2.json"),
+        ),
+        match_querystring=True,
+    )
+    data = await readarr_client.async_get_queue()
+    assert data.page == 1
+    assert data.pageSize == 10
+    assert data.sortKey == ReadarrSortKeys.TIMELEFT.value
+    assert data.sortDirection == SortDirection.ASCENDING.value
+    assert data.totalRecords == 1
+    assert isinstance(data.records[0].authorId, int)
+    assert isinstance(data.records[0].bookId, int)
+    assert data.records[0].author
+    assert data.records[0].book
+    assert isinstance(data.records[0].quality.quality.id, int)
+    assert data.records[0].quality.quality.name == "string"
+    assert isinstance(data.records[0].quality.revision.version, int)
+    assert isinstance(data.records[0].quality.revision.real, int)
+    assert data.records[0].quality.revision.isRepack is False
+    assert isinstance(data.records[0].size, int)
+    assert data.records[0].title == "string"
+    assert data.records[0].sizeleft > 0
+    assert data.records[0].timeleft is None
+    assert data.records[0].estimatedCompletionTime is None
     assert data.records[0].status == "string"
     assert data.records[0].trackedDownloadStatus == "string"
     assert data.records[0].trackedDownloadState == "downloading"
@@ -5824,7 +5868,7 @@ async def test_async_get_queue_details(
     assert data[0].quality.revision.isRepack is False
     assert isinstance(data[0].size, int)
     assert data[0].title == "string"
-    assert isinstance(data[0].sizeleft, int)
+    assert data[0].sizeleft == 0
     assert data[0].timeleft == "00:00:00"
     assert data[0].estimatedCompletionTime == datetime(2020, 2, 7, 11, 27, 27)
     assert data[0].status == "string"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix a situation where some download clients do not provide `timeleft` or `estimatedCompletionTime`. These attributes will now be `None` if not provided. One seems to not be provided without the other. When they do not exist, we have no way of knowing if the download has stopped or is still downloading. So we assume it is downloading in this case.

## Type of change

<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted (`make lint`)
- [x] Tests have been added to verify that the new code works.
